### PR TITLE
Make it compatible to yii2 basic

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -83,6 +83,9 @@ class Module extends \yii\base\Module
     public $showUsernameSupport = true;
 
     public $userNameSupport = 'Support';
+    
+    /** @var boolean If true it makes extension compatible to yii2 basic template */
+    public $yii2basictemplate = false;
 
     /**
      * Translate message

--- a/controllers/CategoryController.php
+++ b/controllers/CategoryController.php
@@ -31,17 +31,21 @@ class CategoryController extends Controller
      */
     public function behaviors()
     {
-        return [
+        $array = [];
+        if (!$this->getModule()->yii2basictemplate) {
+            $array = ['backend' => [
+                'class' => BackendFilter::className(),
+                'actions' => [
+                    '*',
+                ],
+            ]];
+        }
+        
+        return array_merge($array, [
             'verbs' => [
                 'class' => VerbFilter::className(),
                 'actions' => [
                     'delete' => ['POST'],
-                ],
-            ],
-            'backend' => [
-                'class' => BackendFilter::className(),
-                'actions' => [
-                    '*',
                 ],
             ],
             'access' => [
@@ -56,7 +60,7 @@ class CategoryController extends Controller
                     ]
                 ],
             ],
-        ];
+        ]);
     }
 
     /**

--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -27,13 +27,17 @@ class DefaultController extends Controller
      */
     public function behaviors()
     {
-        return [
-            'backend' => [
+        $array = [];
+        if (!$this->getModule()->yii2basictemplate) {
+            $array = ['backend' => [
                 'class' => BackendFilter::className(),
                 'actions' => [
                     '*',
                 ],
-            ],
+            ]];
+        }
+        
+        return array_merge($array, [
             'access' => [
                 'class' => AccessControl::className(),
                 'rules' => [
@@ -46,7 +50,7 @@ class DefaultController extends Controller
                     ],
                 ],
             ],
-        ];
+        ]);
     }
 
     /**

--- a/controllers/TicketController.php
+++ b/controllers/TicketController.php
@@ -31,17 +31,21 @@ class TicketController extends Controller
      */
     public function behaviors()
     {
-        return [
+        $array = [];
+        if (!$this->getModule()->yii2basictemplate) {
+            $array = ['backend' => [
+                'class' => BackendFilter::className(),
+                'actions' => [
+                    '*',
+                ],
+            ]];
+        }
+        
+        return array_merge($array, [
             'verbs' => [
                 'class' => VerbFilter::className(),
                 'actions' => [
                     'delete' => ['POST'],
-                ],
-            ],
-            'backend' => [
-                'class' => BackendFilter::className(),
-                'actions' => [
-                    'manage',
                 ],
             ],
             'access' => [
@@ -61,7 +65,7 @@ class TicketController extends Controller
                     ],
                 ],
             ],
-        ];
+        ]);
     }
 
     /**

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,8 @@ Add following lines to your main configuration file:
 'modules' => [
     'support' => [
         'class' => 'akiraz2\support\Module',
-        'userModel' => 'common\models\User'
+        'userModel' => 'common\models\User',
+        'yii2basictemplate' => false,
     ],
 ],
 ```


### PR DESCRIPTION
Extension is at the moment not working in yii2 basic template.
WIth this PR it can be set that the yii2 basic template is used and then it works.

- add $yii2basictemplate attribute in Module.php
- add attribute in docs

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Fixed issues  | none